### PR TITLE
Use native functions instead of pulling into Elixir

### DIFF
--- a/lib/kenneth/positional/fptp.ex
+++ b/lib/kenneth/positional/fptp.ex
@@ -7,12 +7,14 @@ defmodule Kenneth.Positional.FPTP do
   require Explorer.Series, as: S
 
   def winner(ballots) do
-    for {candidate, s} <- DF.to_series(ballots) do
-      result = s |> S.equal(1) |> S.sum()
-
-      {candidate, result}
-    end
-    |> Enum.max_by(&elem(&1, 1))
-    |> elem(0)
+    ballots
+    |> DF.pivot_longer(DF.names(ballots), names_to: "candidate")
+    |> DF.mutate(value: value == 1)
+    |> DF.group_by("candidate")
+    |> DF.summarise(votes: S.sum(value))
+    |> DF.sort_by(desc: votes)
+    |> DF.pull("candidate")
+    |> S.to_list()
+    |> List.first()
   end
 end


### PR DESCRIPTION
Here's an example of using native Explorer functions rather than just pulling the data into Elixir-land and doing the work there. Takes a few more lines but the `pivot_longer` call can actually be universal -- it takes the data from 'untidy' to 'tidy' data that allows for simpler and more flexible manipulation for analysis (see: [here](https://vita.had.co.nz/papers/tidy-data.pdf) and [here](https://r4ds.had.co.nz/tidy-data.html)).